### PR TITLE
 fix(getsops): correct action script path

### DIFF
--- a/getsops/action.yml
+++ b/getsops/action.yml
@@ -13,6 +13,6 @@ runs:
   steps:
     - name: Set version
       shell: bash
-      run: action.sh
+      run: getsops/action.sh
       env:
         INPUT_VERSION: ${{ inputs.version }}


### PR DESCRIPTION
Fix the path to launch the sops command after downloading the latest version.